### PR TITLE
Fixing #INC-5312: Missing image

### DIFF
--- a/frontend/src/components/Item/index.js
+++ b/frontend/src/components/Item/index.js
@@ -50,8 +50,12 @@ class Item extends React.Component {
           <div className="row bg-white p-4">
             <div className="col-6">
               <img
-                src={this.props.item.image}
-                alt={this.props.item.title}
+                src={
+                  this.props.item.image
+                    ? this.props.item.image
+                    : "../placeholder.png"
+                }
+                alt={"this.props.item.title" + Date.now()}
                 className="item-img"
                 style={{ height: "500px", width: "100%", borderRadius: "6px" }}
               />

--- a/frontend/src/components/ItemPreview.js
+++ b/frontend/src/components/ItemPreview.js
@@ -36,7 +36,7 @@ const ItemPreview = (props) => {
     >
       <img
         alt="item"
-        src={item.image}
+        src={item.image ? item.image : "placeholder.png"}
         className="card-img-top item-img"
         style={{ borderRadius: "20px" }}
       />


### PR DESCRIPTION
Item created without image, is shown on site as broken link
It creates a bad user experience and may look as a bug 
We want to fix it by using a default placeholder image


Added default placeholder image, in case item has no image
This was done in two places:
Item & ItemPreview

Image source '/frontend/public/placeholder.png'

Fix demo attached: 
<img width="866" alt="item" src="https://user-images.githubusercontent.com/17121368/174457342-3d6f2f6b-1fe7-4329-84ed-78865420d88c.png">
<img width="866" alt="preview_item" src="https://user-images.githubusercontent.com/17121368/174457344-1b006713-0834-49cf-b239-e83cec249127.png">

