### PR TITLE
Add default image for Item model + handle empty description

### DIFF
--- a/backend/models/Item.js
+++ b/backend/models/Item.js
@@ -8,7 +8,7 @@ var ItemSchema = new mongoose.Schema(
     slug: { type: String, lowercase: true, unique: true },
     title: String,
     description: String,
-    image: String,
+    image: { type : String,default : "https://via.placeholder.com/400x300.png?text=Item+Image"},
     favoritesCount: { type: Number, default: 0 },
     comments: [{ type: mongoose.Schema.Types.ObjectId, ref: "Comment" }],
     tagList: [{ type: String }],

--- a/frontend/src/components/Item/index.js
+++ b/frontend/src/components/Item/index.js
@@ -39,7 +39,10 @@ class Item extends React.Component {
     }
 
     const markup = {
-      __html: marked(this.props.item.description, { sanitize: true }),
+      __html: marked(
+        this.props.item.description ? this.props.item.description : "",
+        { sanitize: true }
+      ),
     };
     const canModify =
       this.props.currentUser &&

--- a/frontend/src/components/ItemPreview.js
+++ b/frontend/src/components/ItemPreview.js
@@ -43,7 +43,9 @@ const ItemPreview = (props) => {
       <div className="card-body">
         <Link to={`/item/${item.slug}`} className="text-white">
           <h3 className="card-title">{item.title}</h3>
-          <p className="card-text crop-text-3">{item.description}</p>
+          <p className="card-text crop-text-3">
+            {item.description ? item.description : ""}
+          </p>
         </Link>
         <div className="d-flex flex-row align-items-center pt-2">
           <Link to={`/@${item.seller.username}`} className="flex-grow-1">


### PR DESCRIPTION
# Description

When API user create an item without proving image url, item does not render properly on the UI and item screen has only its background image 
- Added default image URL https://via.placeholder.com/400x300.png?text=Item+Image to Item model to have default value

When item has NULL description, item screen does not loaded item does not render properly on the UI and item screen has only its background image 
- Added in front end check if description is Null and if it is, set empty string ("") so the item will be rendered properly 